### PR TITLE
Feature/expose k8s version

### DIFF
--- a/ci/minimum-release-verification/manifest.yml
+++ b/ci/minimum-release-verification/manifest.yml
@@ -41,6 +41,8 @@ instance_groups:
         release: docker
 #      - name: print-etcd-component-version
 #        release: cfcr-etcd
+      - name: expose-versions
+        release: kubo
     vm_type: micro
     stemcell: linux
     # in megabytes

--- a/ci/minimum-release-verification/run-tests/task.sh
+++ b/ci/minimum-release-verification/run-tests/task.sh
@@ -64,7 +64,7 @@ bosh run-errand \
 
 EXPOSED_KUBERNETES_VERSION="$(cat expose_versions.txt | \
   jq .Tables[0].Rows[0].stdout --raw-output | \
-  jq .kubernetes_version --raw-output)"
+  jq '.["kubernetes-version"]' --raw-output)"
 
 if [ "$LINUX_VERSION" == "$EXPOSED_KUBERNETES_VERSION" ]
 then

--- a/ci/scripts/download_k8s_binaries_common_core
+++ b/ci/scripts/download_k8s_binaries_common_core
@@ -38,6 +38,19 @@ main() {
         sed -E -i -e "s/${existing_k8s_spec}/kubernetes-${kubernetes_version}/" spec
       popd || exit 1
 
+      pushd "jobs/expose-versions"
+        bosh int -o <(cat <<EOF
+- type: replace
+  path: /properties/kubernetes-version/default
+  value: "${kubernetes_version}"
+EOF) spec > new-spec
+        mv new-spec spec
+      popd
+
+      pushd "packages/expose-versions"
+        sed -E -i -e "s/KUBERNETES_VERSION='([0-9]+\.)+[0-9]+'/KUBERNETES_VERSION='${kubernetes_version}'/" packaging
+      popd
+
       echo "Downloading from common core"
       download_tarball_from_common_core "${kubernetes_version}" "${staging_dir}"
 

--- a/ci/scripts/download_k8s_binaries_google
+++ b/ci/scripts/download_k8s_binaries_google
@@ -37,6 +37,19 @@ main() {
         sed -E -i -e "s/${existing_k8s_spec}/kubernetes-${kubernetes_version}/" spec
       popd
 
+      pushd "jobs/expose-versions"
+        bosh int -o <(cat <<EOF
+- type: replace
+  path: /properties/kubernetes-version/default
+  value: "${kubernetes_version}"
+EOF) spec > new-spec
+        mv new-spec spec
+      popd
+
+      pushd "packages/expose-versions"
+        sed -E -i -e "s/KUBERNETES_VERSION='([0-9]+\.)+[0-9]+'/KUBERNETES_VERSION='${kubernetes_version}'/" packaging
+      popd
+
       for binary in "${binaries[@]}"; do
         download "${binary}" "${staging_dir}" "${kubernetes_version}"
         add_blob "${binary}" "${staging_dir}" "${kubernetes_version}"

--- a/jobs/expose-versions/spec
+++ b/jobs/expose-versions/spec
@@ -7,14 +7,14 @@ packages: []
 
 properties:
   kubernetes-version:
-    description: The current version of kubernetes.  THIS IS AUTOMATICALLY GENERATED, DO NOT MANUALLY EDIT
-    default: 1.16.7
+    description: "The current version of kubernetes.  THIS IS AUTOMATICALLY GENERATED, DO NOT MANUALLY EDIT"
+    default: "1.16.7"
   docker-version:
-    description: The current version of docker.  TODO: keep in sync with pks-docker-boshrelease until repos are merged
-    default: 18.09.9
+    description: "The current version of docker.  TODO: keep in sync with pks-docker-boshrelease until repos are merged"
+    default: "18.09.9"
   etcd-version:
-    description: The current version of etcd.  TODO: keep in sync with pks-cfcr-etcd-release until repos are merged
-    default: 3.3.17
+    description: "The current version of etcd.  TODO: keep in sync with pks-cfcr-etcd-release until repos are merged"
+    default: "3.3.17"
 
 provides:
 - name: expose-versions
@@ -23,4 +23,3 @@ provides:
   - docker-version
   - etcd-version
   type: expose-versions
-  

--- a/jobs/expose-versions/spec
+++ b/jobs/expose-versions/spec
@@ -1,0 +1,25 @@
+---
+name: expose-versions
+
+templates: {}
+
+packages: []
+
+properties:
+  kubernetes-version:
+    description: The current version of kubernetes.  THIS IS AUTOMATICALLY GENERATED, DO NOT MANUALLY EDIT
+    default: 1.16.7
+  docker-version:
+    description: The current version of docker.  TODO: keep in sync with pks-docker-boshrelease until repos are merged
+    default: 18.09.9
+  etcd-version:
+    description: The current version of etcd.  TODO: keep in sync with pks-cfcr-etcd-release until repos are merged
+    default: 3.3.17
+
+provides:
+- name: expose-versions
+  properties:
+  - kubernetes-version
+  - docker-version
+  - etcd-version
+  type: expose-versions

--- a/jobs/expose-versions/spec
+++ b/jobs/expose-versions/spec
@@ -23,3 +23,4 @@ provides:
   - docker-version
   - etcd-version
   type: expose-versions
+  

--- a/jobs/expose-versions/spec
+++ b/jobs/expose-versions/spec
@@ -20,4 +20,5 @@ provides:
   - docker-version
   - etcd-version
   type: expose-versions
-templates: {}
+templates:
+    run.erb: bin/run

--- a/jobs/expose-versions/spec
+++ b/jobs/expose-versions/spec
@@ -1,21 +1,18 @@
----
 name: expose-versions
-
-templates: {}
-
 packages: []
-
 properties:
-  kubernetes-version:
-    description: "The current version of kubernetes.  THIS IS AUTOMATICALLY GENERATED, DO NOT MANUALLY EDIT"
-    default: "1.16.7"
   docker-version:
-    description: "The current version of docker.  TODO: keep in sync with pks-docker-boshrelease until repos are merged"
-    default: "18.09.9"
+    default: 18.09.9
+    description: 'The current version of docker.  TODO: keep in sync with pks-docker-boshrelease
+      until repos are merged'
   etcd-version:
-    description: "The current version of etcd.  TODO: keep in sync with pks-cfcr-etcd-release until repos are merged"
-    default: "3.3.17"
-
+    default: 3.3.17
+    description: 'The current version of etcd.  TODO: keep in sync with pks-cfcr-etcd-release
+      until repos are merged'
+  kubernetes-version:
+    default: 1.16.7
+    description: The current version of kubernetes.  THIS IS AUTOMATICALLY GENERATED,
+      DO NOT MANUALLY EDIT
 provides:
 - name: expose-versions
   properties:
@@ -23,3 +20,4 @@ provides:
   - docker-version
   - etcd-version
   type: expose-versions
+templates: {}

--- a/jobs/expose-versions/templates/run.erb
+++ b/jobs/expose-versions/templates/run.erb
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-echo "{ \"kubernetes-version\": \"<% p("kubernetes-version") %>\" }"
+echo "{ \"kubernetes-version\": \"<%= p("kubernetes-version") %>\" }"

--- a/jobs/expose-versions/templates/run.erb
+++ b/jobs/expose-versions/templates/run.erb
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "{ \"kubernetes-version\": \"<% p("kubernetes-version") %>\" }"

--- a/packages/expose-versions/packaging
+++ b/packages/expose-versions/packaging
@@ -1,0 +1,17 @@
+set -e
+
+# These values are automatically updated by bump-k8s.sh
+# DO NOT MANUALLY MODIFY THEM
+KUBERNETES_VERSION="1.16.7"
+# TODO: this should be kept in sync with pks-docker-boshrelease until we merge repos
+DOCKER_VERSION="18.09"
+# TODO: this should be kept in sync with pks-cfcr-etcd-release until we merge repos
+ETCD_VERSION="3.3.17"
+
+cat <<EOF > ${BOSH_INSTALL_TARGET}/expose-versions.json
+{
+    "kubernetes-version": "$KUBERNETES_VERSION",
+    "docker-version": "$DOCKER_VERSION",
+    "etcd-version": "$ETCD_VERSION"
+}
+EOF

--- a/packages/expose-versions/packaging
+++ b/packages/expose-versions/packaging
@@ -2,7 +2,7 @@ set -e
 
 # These values are automatically updated by bump-k8s.sh
 # DO NOT MANUALLY MODIFY THEM
-KUBERNETES_VERSION="1.16.7"
+KUBERNETES_VERSION='1.16.7'
 # TODO: this should be kept in sync with pks-docker-boshrelease until we merge repos
 DOCKER_VERSION="18.09"
 # TODO: this should be kept in sync with pks-cfcr-etcd-release until we merge repos

--- a/packages/expose-versions/packaging
+++ b/packages/expose-versions/packaging
@@ -4,9 +4,9 @@ set -e
 # DO NOT MANUALLY MODIFY THEM
 KUBERNETES_VERSION='1.16.7'
 # TODO: this should be kept in sync with pks-docker-boshrelease until we merge repos
-DOCKER_VERSION="18.09"
+DOCKER_VERSION='18.09.9'
 # TODO: this should be kept in sync with pks-cfcr-etcd-release until we merge repos
-ETCD_VERSION="3.3.17"
+ETCD_VERSION='3.3.17'
 
 cat <<EOF > ${BOSH_INSTALL_TARGET}/expose-versions.json
 {

--- a/packages/expose-versions/spec
+++ b/packages/expose-versions/spec
@@ -1,0 +1,6 @@
+---
+name: expose-versions
+
+dependencies: []
+
+files: []


### PR DESCRIPTION
This adds both a job and a package which exposes the versions of the components we ship in the BOSH Lifecycle team.  Core team can choose which implementation we want to go forward with.