### PR TITLE
Bumps kubernetes 1.18.3+vmware.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,30 +18,30 @@ cni/util-linux_2.27.1-6ubuntu3_amd64.deb:
   size: 847730
   object_id: 27eb3ec3-220f-4a25-6c4f-ec219c37ac8d
   sha: 568f62cb031608ab09ba1e3c2121e9e8b92dcae4
-common-core-kubernetes-1.17.3/kube-apiserver:
-  size: 159836595
-  object_id: 344d6edf-b3c2-43a0-5f8d-462d87280b11
-  sha: 1aa8e0e0e5986cb4e846194cfc8b4c9049bedf61
-common-core-kubernetes-1.17.3/kube-controller-manager:
-  size: 148336013
-  object_id: 363084a6-7121-418d-4ad9-a6e5ba17e69b
-  sha: ec5f686a8ee4a9d05d5c3961c75f790fe1c94343
-common-core-kubernetes-1.17.3/kube-proxy:
-  size: 51957485
-  object_id: 6675735f-3829-47ef-5687-31bc9afbf86b
-  sha: c8584f012930dae0f5f655ed2061af0f25699fe0
-common-core-kubernetes-1.17.3/kube-scheduler:
-  size: 58057786
-  object_id: 8a98a943-6fc1-4402-7bf9-9bd99be6b75f
-  sha: bc7298140106725f803b7d3a1d789f91847cf6c0
-common-core-kubernetes-1.17.3/kubectl:
-  size: 59360015
-  object_id: 47b35e93-4a56-401a-7d92-8bb2a674d206
-  sha: 274f141c636a93b75ba5d3a9dc8da7ec53b1608c
-common-core-kubernetes-1.17.3/kubelet:
-  size: 150522168
-  object_id: dda6d002-ffe0-414b-4bd5-2bbba3dc1b0c
-  sha: 8fc16c2c8e31892055e539d1cec3069500224932
+common-core-kubernetes-1.18.3+vmware.1/kube-apiserver:
+  size: 162367844
+  object_id: b0cf5ff9-59c7-4841-6552-1b1406414dff
+  sha: sha256:50899cb7fb2bc9bb71fe2a23f7680f8cae69362be8362c205f2f9252ab69c8d5
+common-core-kubernetes-1.18.3+vmware.1/kube-controller-manager:
+  size: 150182157
+  object_id: 4063132e-3f48-47b4-559d-06a20dd8c6e9
+  sha: sha256:c6fad7d89c2e8db8e1661bda1ac19aa27ebebc92e5ddcd16ee65b54b2e8c20a5
+common-core-kubernetes-1.18.3+vmware.1/kube-proxy:
+  size: 52716792
+  object_id: 920648dc-4e6c-4229-59a7-8a9c7455e519
+  sha: sha256:50d3a8826ecd92c8359a8f9e716ed7544434a76e851120b947c40a70ff9c8011
+common-core-kubernetes-1.18.3+vmware.1/kube-scheduler:
+  size: 59212588
+  object_id: c29e71b2-9ab4-4396-4578-d4a4bb6f4f6c
+  sha: sha256:fe735dbd24fb4c1e4866ba89602d90d9617ed7fc1870bc3bb8ad1f248818f021
+common-core-kubernetes-1.18.3+vmware.1/kubectl:
+  size: 60060368
+  object_id: a57c2278-46d2-4db1-636a-7cbb9512a5e4
+  sha: sha256:f3a49d66b260cea287d394a97a7f17ee863ddae99384f6d8c08f3d11e532562b
+common-core-kubernetes-1.18.3+vmware.1/kubelet:
+  size: 152663392
+  object_id: ce23e87c-c4d1-446e-66af-0c9d6f076ef1
+  sha: sha256:c596f09ce25721622243502d7a9185d0c48d0b75c7dd9ab9ac4e187f73b9650c
 conntrack/conntrack_1.4.3-3_amd64.deb:
   size: 27346
   object_id: 0c4aa633-3de8-4a8c-7170-36b3fc9e4a9c

--- a/packages/kubernetes/packaging
+++ b/packages/kubernetes/packaging
@@ -1,7 +1,7 @@
 set -e
 
 KUBERNETES_PACKAGE=common-core-kubernetes
-KUBERNETES_VERSION="1.17.3"
+KUBERNETES_VERSION="1.18.3+vmware.1"
 
 main() {
   create_target_dir

--- a/packages/kubernetes/spec
+++ b/packages/kubernetes/spec
@@ -3,4 +3,4 @@ name: kubernetes
 
 files:
 - container-images/*
-- common-core-kubernetes-1.17.3/*
+- common-core-kubernetes-1.18.3+vmware.1/*


### PR DESCRIPTION
Authored-by: Todd Sedano <tsedano@pivotal.io>

**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**

**Is there any change in kubo-deployment?**

**Is there any change in kubo-ci?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
