### PR TITLE
Pipeline add 1.10 and adjust 1.9

### DIFF
--- a/ci/bump-k8s-for-pks-1.10.yml
+++ b/ci/bump-k8s-for-pks-1.10.yml
@@ -16,7 +16,7 @@ resources:
   type: s3
   source:
     bucket: "essentialpks-staging"
-    regexp: "vmware-tanzu-kubernetes-grid/523a448aa3e9a0ef93ff892dceefee0a/kubernetes-binary-v(1.18.\\d*.vmware.*).tar.gz"
+    regexp: "vmware-tanzu-kubernetes-grid/523a448aa3e9a0ef93ff892dceefee0a/kubernetes-binary-v(1.19.\\d*.vmware.*).tar.gz"
     region_name: "us-west-2"
 
 - name: gcs-kubernetes-windows
@@ -24,7 +24,7 @@ resources:
   source:
       bucket: "kubernetes-release"
       json_key: ((gcs-json-key))
-      regexp: "release/v(1.18.\\d*)/bin/windows/amd64/kube-proxy.exe"
+      regexp: "release/v(1.19.\\d*)/bin/windows/amd64/kube-proxy.exe"
 
 - name: git-pks-kubernetes-release-ci
   type: git
@@ -37,14 +37,14 @@ resources:
   type: git
   source:
     uri: git@github.com:pivotal-cf/pks-kubernetes-release.git
-    branch: 1.9.x
+    branch: main
     private_key: ((git-ssh-key.private_key))
 
 - name: git-pks-kubernetes-windows-release
   type: git
   source:
     uri: git@github.com:pivotal-cf/pks-kubernetes-windows-release.git
-    branch: 1.9.x
+    branch: main
     private_key: ((git-ssh-key.private_key))
 
 jobs:
@@ -69,7 +69,7 @@ jobs:
         - name: git-pks-kubernetes-release-ci
         - name: s3-kubernetes-common-core-linux
       params:
-        BASE_BRANCH: 1.9.x
+        BASE_BRANCH: main
         BINARY_DIRECTORY: s3-kubernetes-common-core-linux
         BUMP_DOCKER: true
         USE_COMMON_CORE: true
@@ -98,7 +98,7 @@ jobs:
           - name: git-pks-kubernetes-windows-release-output
         params:
           REPO: windows
-          BASE_BRANCH: 1.9.x
+          BASE_BRANCH: main
           BINARY_DIRECTORY: gcs-kubernetes-windows
           BUMP_DOCKER: true
           GCS_JSON_KEY: ((gcs-bosh-blobstore-json-key))


### PR DESCRIPTION
  bump-k8s-1.x.x piplines

**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**
https://pks.ci.cf-app.com/teams/bosh-lifecycle/pipelines/bump-k8s-for-pks-1.9/jobs/bump-dependencies-in-pks-kubo-release-windows/builds/13
https://pks.ci.cf-app.com/teams/bosh-lifecycle/pipelines/bump-k8s-for-pks-1.10/jobs/bump-dependencies-in-pks-kubo-release-windows/builds/1
**Is there any change in kubo-deployment?**
N
**Is there any change in kubo-ci?**
N
**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
