### PR TITLE
Bump kubernetes 1.17.13+vmware.1

### DIFF
--- a/ci/scripts/download_common_core_from_build_web.rb
+++ b/ci/scripts/download_common_core_from_build_web.rb
@@ -66,7 +66,7 @@ end
 
 def git_commit_and_push(release_dir, kubernetes_version)
   Dir.chdir release_dir do
-    execute_system_call("git co -b bump-kubernetes-#{kubernetes_version}")
+    execute_system_call("git checkout -b bump-kubernetes-#{kubernetes_version}")
     execute_system_call("git add config/blobs.yml")
     execute_system_call("git add packages/kubernetes/packaging")
     execute_system_call("git add packages/kubernetes/spec")
@@ -138,10 +138,10 @@ def main(bora_number, kubernetes_version)
 end
 
 
-bora_number = "16772990"
+bora_number = "17113719"
 # When setting this, be sure not to include the 'v' at the beginning of the version
 # as well as be sure to leave the build number off (...+vmware.1 is correct,
 # ...+vmware.1.68 is not).
-kubernetes_version = "1.17.11+vmware.1"
+kubernetes_version = "1.17.13+vmware.1"
 
 main(bora_number, kubernetes_version)

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,38 +10,38 @@ cifs-utils-6.7.tar.bz2:
   size: 363647
   object_id: c529967d-57fa-4b41-685e-ff0a507ffaad
   sha: 9ba5091d7c2418a90773c861f04a3f4a36854c14
-cni/cni-plugins-v0.8.6+vmware.1.tgz:
-  size: 36876712
-  object_id: 255e1581-26a8-4a2d-6e92-02173b45613c
-  sha: sha256:f56b6fb3d48cdb8ed859ffc2eb6e8d831f4f004eb6465b4dd8bd7a542d008b5e
+cni/cni-plugins-v0.8.7+vmware.3.tgz:
+  size: 38217101
+  object_id: e938094b-3809-4cd3-5324-c149cb95f6e9
+  sha: sha256:d9add70f83d7768427e5c92640306801d9536190508c6f44f1f8b78c77555a71
 cni/util-linux_2.27.1-6ubuntu3_amd64.deb:
   size: 847730
   object_id: 27eb3ec3-220f-4a25-6c4f-ec219c37ac8d
   sha: 568f62cb031608ab09ba1e3c2121e9e8b92dcae4
-common-core-kubernetes-1.17.11+vmware.1/kube-apiserver:
-  size: 160063241
-  object_id: 3f3be08d-f8a8-4270-5894-c624c06474dd
-  sha: sha256:afb9f90faca4652561ae1aa3b8c18b2edc53a5037feed04a3a46d3862e34218c
-common-core-kubernetes-1.17.11+vmware.1/kube-controller-manager:
-  size: 148471383
-  object_id: 8833de1a-4956-435f-7325-5db83141538d
-  sha: sha256:6b71fff8de5d2f6f49e32e647f0e1d03d62d75630b53b5ce4eca8292e1ef0435
-common-core-kubernetes-1.17.11+vmware.1/kube-proxy:
+common-core-kubernetes-1.17.13+vmware.1/kube-apiserver:
+  size: 160031311
+  object_id: 51b7b3a0-cbc2-4abe-5f81-5fd1e76515ce
+  sha: sha256:46330901139e6298986a540dd2ae0a88b5c63251a4623c9f1087a1f95119933e
+common-core-kubernetes-1.17.13+vmware.1/kube-controller-manager:
+  size: 148475608
+  object_id: 660c1340-741f-4fba-5ab5-c84e48088ad5
+  sha: sha256:186679e0649f44bb431406141ee0fd0fdfebdc91519fb59b8b805f182cf2d923
+common-core-kubernetes-1.17.13+vmware.1/kube-proxy:
   size: 51957759
-  object_id: cf396359-4ef2-4a0d-69b1-4b162e7b6b29
-  sha: sha256:05a2f04663867f8de8cafc32e4610fd3ea36f9bf2d3719393e234e9428567712
-common-core-kubernetes-1.17.11+vmware.1/kube-scheduler:
+  object_id: d7aed413-4123-4937-4fda-c6f3d3754a5a
+  sha: sha256:d504cb285f2bb4fe196b0c8fe270de71e2a62b63510cc064d7a5cec5f6d6e8d0
+common-core-kubernetes-1.17.13+vmware.1/kube-scheduler:
   size: 58100098
-  object_id: 262f37de-74db-4117-543e-a32e9829aa1d
-  sha: sha256:eb914f1d5e4f51a8f6690a89a8ec90f8f96415e97a23f7a45003da03253399e7
-common-core-kubernetes-1.17.11+vmware.1/kubectl:
-  size: 59403188
-  object_id: 67aa7f77-cb89-4382-59ea-3ccc5f134492
-  sha: sha256:4b92bee8a13751c3429d8c5a02f99308f736937a864ecd727d55bfd720a04356
-common-core-kubernetes-1.17.11+vmware.1/kubelet:
-  size: 150671800
-  object_id: 4f142c5a-1830-49ea-75a0-b433fbf78e95
-  sha: sha256:3e675091ebf51c9eb093a7103e685bc4f535e5d1ed4528d85d4e8b92cb0a4ce4
+  object_id: 685b25b7-b519-4a97-43f8-f5fa539204c2
+  sha: sha256:edc096fc2f1d9e769731d5aa26032c84660a725e83ac6b85079ed204f77e847b
+common-core-kubernetes-1.17.13+vmware.1/kubectl:
+  size: 59391139
+  object_id: a4a3bd03-4023-4eb6-7686-a2537d5fdba5
+  sha: sha256:636e59a750f54f0716e5c3a738e49b56f0f085d127c77e85090b142d9c0bd85d
+common-core-kubernetes-1.17.13+vmware.1/kubelet:
+  size: 150691856
+  object_id: bd5e0aeb-2ea3-4b9f-5ccd-713098975b56
+  sha: sha256:a4c7a4374b3677b320537739da5c7d6f77dec59650e69e865ff649339c9ea35a
 conntrack/conntrack_1.4.3-3_amd64.deb:
   size: 27346
   object_id: 0c4aa633-3de8-4a8c-7170-36b3fc9e4a9c
@@ -54,10 +54,10 @@ container-images/simple-server.tgz:
   size: 26963968
   object_id: 7c6360a4-3814-455b-6e87-c0f8b78dc06c
   sha: sha256:4768953f60210d525fba95956612ffd7c3b99720da4e40bb6c94352e6fbaf9a5
-container-images/vmware_coredns:1.6.5_vmware.7.tgz:
-  size: 13125350
-  object_id: fdcd3b76-190f-44f4-513b-9d87b805c305
-  sha: sha256:30be682ab1220b6d68263ac7ebc4f4e3bcac167ab6064884341f39ed43e298d5
+container-images/vmware_coredns:1.6.5_vmware.10.tgz:
+  size: 11557511
+  object_id: 2d3dcd81-0078-49a2-62ad-9619f230f22a
+  sha: sha256:0cf8453e3df6cc96d08d0ea0983afe662b5a9d67ee670483cab73195983840d1
 container-images/vmware_metrics-server-amd64:v0.3.6.tgz:
   size: 12062146
   object_id: 301b9879-c1bf-42bb-6d90-f05929118056

--- a/jobs/apply-specs/templates/specs/coredns.yml.erb
+++ b/jobs/apply-specs/templates/specs/coredns.yml.erb
@@ -102,7 +102,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: registry.tkg.vmware.run/coredns:v1.6.5_vmware.7
+        image: registry.tkg.vmware.run/coredns:v1.6.5_vmware.10
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/packages/cni/packaging
+++ b/packages/cni/packaging
@@ -3,9 +3,9 @@ set -exu
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 
 CNI_PACKAGE="cni-plugins"
-CNI_VERSION="0.8.6"
+CNI_VERSION="0.8.7"
 
-tar -xzf cni/${CNI_PACKAGE}-v${CNI_VERSION}+vmware.1.tgz -C ${BOSH_INSTALL_TARGET}/bin/
+tar -xzf cni/${CNI_PACKAGE}-v${CNI_VERSION}+vmware.3.tgz -C ${BOSH_INSTALL_TARGET}/bin/
 
 mkdir -p utillocal
 dpkg -x cni/util-linux*.deb utillocal/

--- a/packages/cni/spec
+++ b/packages/cni/spec
@@ -2,5 +2,5 @@
 name: cni
 
 files:
-- cni/cni-plugins-v0.8.6+vmware.1.tgz
+- cni/cni-plugins-v0.8.7+vmware.3.tgz
 - cni/util-linux_2.27.1-6ubuntu3_amd64.deb

--- a/packages/kubernetes/packaging
+++ b/packages/kubernetes/packaging
@@ -1,7 +1,7 @@
 set -e
 
 KUBERNETES_PACKAGE=common-core-kubernetes
-KUBERNETES_VERSION="1.17.11+vmware.1"
+KUBERNETES_VERSION="1.17.13+vmware.1"
 
 main() {
   create_target_dir

--- a/packages/kubernetes/spec
+++ b/packages/kubernetes/spec
@@ -3,4 +3,4 @@ name: kubernetes
 
 files:
 - container-images/*
-- common-core-kubernetes-1.17.11+vmware.1/*
+- common-core-kubernetes-1.17.13+vmware.1/*


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**
https://pks.ci.cf-app.com/teams/bosh-lifecycle-dev/pipelines/pks-api-1.8.x-bump-kubernetes-1.17.13

**Is there any change in kubo-deployment?**

**Is there any change in kubo-ci?**
NO

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
