### PR TITLE
Remove nginx-ingress-controller images

### DIFF
--- a/jobs/kubelet/spec
+++ b/jobs/kubelet/spec
@@ -5,6 +5,7 @@ templates:
   bin/kubelet_ctl.erb: bin/kubelet_ctl
   bin/pre-start: bin/pre-start
   bin/post-start.erb: bin/post-start
+  bin/post-stop.erb: bin/post-stop
   config/apiserver-ca.pem.erb: config/apiserver-ca.pem
   config/cloud-provider.ini.erb: config/cloud-provider.ini
   config/file-arguments.json.erb: config/file-arguments.json

--- a/jobs/kubelet/templates/bin/post-stop.erb
+++ b/jobs/kubelet/templates/bin/post-stop.erb
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+nginx_images=$(/var/vcap/jobs/kubelet/packages/docker/bin/docker images| grep nginx-ingress-controller | awk '{print $3}')
+
+# https://pivotal-spike.atlassian.net/browse/PKS-901
+# Removing the cached layers of nginx-ingress-controller
+# https://github.com/helm/charts/issues/15994#issuecomment-545986998
+for img in ${nginx_images}; do
+    echo "removing image ${img}"
+    /var/vcap/jobs/kubelet/packages/docker/bin/docker rmi -f ${img}
+done
+
+exit 0


### PR DESCRIPTION
Remove nginx-ingress-controller images during post-stop to fix
PKS-901 issue.

**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**

**Is there any change in kubo-deployment?**

**Is there any change in kubo-ci?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
