### PR TITLE
Fix the node taint parameter name

### DIFF
--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -52,14 +52,6 @@ kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/k
   labels = labels.join(",")
 %>
 
-<%  
-  taints = ""
-  if_p('k8s-args') do |args|
-    taints = args.fetch('node-taints', "")
-    args.delete('node-taints')
-  end  
-%>
-
 # shellcheck disable=SC1091
 . /var/vcap/packages/pid_utils/pid_utils.sh
 
@@ -173,7 +165,6 @@ start_kubelet() {
     <% if !iaas.nil? -%>--cloud-provider=${cloud_provider}<% end %> \
     --hostname-override=$(get_hostname_override) \
     --node-labels=<%= labels %> \
-    --register-with-taints=<%= taints %> \
     --config="/var/vcap/jobs/kubelet/config/kubeletconfig.yml" \
     --tls-cipher-suites=<%= link('kube-apiserver').p('tls-cipher-suites') %> \
   1>> $LOG_DIR/kubelet.stdout.log \


### PR DESCRIPTION
In my previous PR, I added "node-taints" into the k8s-args for kubelet, and translated it to "--register-with-taints". Actually it isn't correct. 

We only need to set the correct name "register-with-taints" into k8s-args, and then the kubelet_ctl script will  automatically insert the parameter for kubelet. So this change is just to rollback the change in my last PR. 