### PR TITLE
add additional volumes if antrea cni

### DIFF
--- a/jobs/kube-apiserver/templates/config/bpm.yml.erb
+++ b/jobs/kube-apiserver/templates/config/bpm.yml.erb
@@ -23,6 +23,13 @@ processes:
   executable: /var/vcap/packages/kubernetes/bin/kube-apiserver
   limits:
     open_files: 65535
+  <% if_p('k8s-args.egress-selector-config-file') do |egress_selector_config_file| %>
+  additional_volumes:
+  - path: /var/vcap/store/kubo-apiserver
+    writable: false
+  - path: /var/vcap/data/kubo-apiserver
+    writable: true
+  <% end %>
   args:
   <%
     if_p('k8s-args') do |args|


### PR DESCRIPTION
**What this PR does / why we need it**:
proxy-servier for antrea needs additional volumes to communicate with apiserver

**How can this PR be verified?**

can be verified by installing tile, check if path created successfully

**Is there any change in kubo-deployment?**
no

**Is there any change in kubo-ci?**
no

**Does this affect upgrade, or is there any migration required?**
no

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
