### PR TITLE
Bumps kubernetes 1.18.12+vmware.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,38 +10,38 @@ cifs-utils-6.7.tar.bz2:
   size: 363647
   object_id: c529967d-57fa-4b41-685e-ff0a507ffaad
   sha: 9ba5091d7c2418a90773c861f04a3f4a36854c14
-cni/cni-plugins-amd64-v0.8.6+vmware.2.tgz:
-  size: 36876641
-  object_id: a623b3b9-5a61-42e7-4121-8f9e0698acd0
-  sha: sha256:501d701eec70ca8d4680fe648c78dd1197e3d502a6a0168913a4fe2574effea0
+cni/cni-plugins-amd64-v0.8.7+vmware.3.tgz:
+  size: 39810209
+  object_id: 137a8783-fc99-4811-78b6-e85d878ec289
+  sha: sha256:f50c9c152223f03ddbfa0d8deafebce9ea2720ecd838c28aee4e4680ce3be5e3
 cni/nsenter-2.27.1:
   size: 27520
   object_id: f78a843e-4bf1-47c4-578b-786fcf8a2c94
   sha: sha256:9999ffda41275f924bcbb1d9d7b129421838d917236511eccacae7dc0ad631a9
-common-core-kubernetes-1.18.8+vmware.1/kube-apiserver:
-  size: 162404215
-  object_id: af84733a-5063-4d96-52ce-3fb4fc9b2417
-  sha: sha256:1f9e15bf2aecc10c8815bfc7a884b68c03f0b02e88f87851fe2738a70e214d31
-common-core-kubernetes-1.18.8+vmware.1/kube-controller-manager:
-  size: 150244162
-  object_id: c394644a-df5f-4a2d-5fb8-05747e2bec5b
-  sha: sha256:d6967a94fd9c09fa2bbe38fd49fc0bbd4853b62685511e02e7e79a201d1a3168
-common-core-kubernetes-1.18.8+vmware.1/kube-proxy:
-  size: 52725654
-  object_id: 34d3f760-367d-4d79-61e0-75448db7e4d1
-  sha: sha256:8e534695c9fa4f2aca93cdbb3acc83180362c8b3cf6fccd7d2e6a9ba9b7b4249
-common-core-kubernetes-1.18.8+vmware.1/kube-scheduler:
-  size: 59244539
-  object_id: 6e9616e0-5fdd-43fa-4c22-3ee8ce055814
-  sha: sha256:a72c207cb57bc41db4589637b1eee660448b2c33c2ee860121af15f0b70ef40c
-common-core-kubernetes-1.18.8+vmware.1/kubectl:
-  size: 60077962
-  object_id: dc3cb93c-06df-4f3d-471b-bbcba9dc5e15
-  sha: sha256:6bcf890b226299a3f25a1e17774168467c271e18e8c7aabad30c4aa78c52df2b
-common-core-kubernetes-1.18.8+vmware.1/kubelet:
-  size: 152695784
-  object_id: bfd47f74-db3d-4e0f-54ac-ab016a75496c
-  sha: sha256:c865d1578b4cdc6908476db93dcaa908deef8bb1948d3458b1fd69dc14165b41
+common-core-kubernetes-1.18.12+vmware.2/kube-apiserver:
+  size: 162415807
+  object_id: 2e08674d-746c-4c86-57d8-1238ac5cfa8e
+  sha: sha256:ff2549726aeee613d28063937b2154f48f16559ea11c8bb9dc00b3a7c1b3a8a1
+common-core-kubernetes-1.18.12+vmware.2/kube-controller-manager:
+  size: 150267407
+  object_id: 7eb9b450-036f-4f55-5142-28cb474ba919
+  sha: sha256:4a9a15f48a9725a51ec297127fe559619ef140b0711f224951f330327a1e0e83
+common-core-kubernetes-1.18.12+vmware.2/kube-proxy:
+  size: 52725667
+  object_id: 14933d73-ff60-461c-5c2c-e6ef6224dac6
+  sha: sha256:a6607e109e834ac4b78b5d84ce64a196c32346b9684392ca24c00d6b14f79673
+common-core-kubernetes-1.18.12+vmware.2/kube-scheduler:
+  size: 59248826
+  object_id: e0e9cc0b-a011-4556-7148-6544b4392caa
+  sha: sha256:fe5cb890bd3f755e3f29fcf73df679054102b410fe54281b3eb7347aee277814
+common-core-kubernetes-1.18.12+vmware.2/kubectl:
+  size: 60078035
+  object_id: 5591e69b-56c4-4379-68bc-291464e71924
+  sha: sha256:ebd6765109690784247bb9729fba9f0f2da34c322de016c44bcf3f1ad78566ef
+common-core-kubernetes-1.18.12+vmware.2/kubelet:
+  size: 152768792
+  object_id: c1fef481-0ffe-483e-4fd4-3b6d64328a0e
+  sha: sha256:60f4631d32746a31a0071b2dda5f92eab00cfcdbb6a86c8c6710bc2b520a4988
 conntrack/conntrack_1.4.3-3_amd64.deb:
   size: 27346
   object_id: 0c4aa633-3de8-4a8c-7170-36b3fc9e4a9c
@@ -54,10 +54,10 @@ container-images/simple-server.tgz:
   size: 11953836
   object_id: d362a1a2-0a96-4e73-67a6-2e8565edc489
   sha: sha256:8c0c566079241cb5ec0c6708b47e2ee71b5dc470caa1cef62b0b2c671e784ef8
-container-images/vmware_coredns:1.6.7_vmware.3.tgz:
-  size: 13478434
-  object_id: fb7b9618-03f8-4b33-7eb5-ebbc0b27d3a0
-  sha: sha256:c6d4777cd6484bf23d91bdbc27b565eda0755e18f8aadfd431f070264ae869f8
+container-images/vmware_coredns:1.6.7_vmware.6.tgz:
+  size: 12202440
+  object_id: 89fac37a-f060-4db6-46c5-fd5ad6d50c7a
+  sha: sha256:e7e7806ea1203d929435df5a9aec142c443e9b63b775828c852e7365514f3ec7
 container-images/vmware_metrics-server-amd64:v0.3.6.tgz:
   size: 12062146
   object_id: 301b9879-c1bf-42bb-6d90-f05929118056

--- a/jobs/apply-specs/templates/specs/coredns.yml.erb
+++ b/jobs/apply-specs/templates/specs/coredns.yml.erb
@@ -102,7 +102,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: registry.tkg.vmware.run/coredns:v1.6.7_vmware.3
+        image: registry.tkg.vmware.run/coredns:v1.6.7_vmware.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/packages/cni/packaging
+++ b/packages/cni/packaging
@@ -3,7 +3,7 @@ set -exu
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 
 CNI_PACKAGE="cni-plugins"
-CNI_VERSION="0.8.6+vmware.2"
+CNI_VERSION="0.8.7+vmware.3"
 
 NSENTER_VERSION="2.27.1"
 

--- a/packages/cni/spec
+++ b/packages/cni/spec
@@ -2,5 +2,5 @@
 name: cni
 
 files:
-- cni/cni-plugins-amd64-v0.8.6+vmware.2.tgz
+- cni/cni-plugins-amd64-v0.8.7+vmware.3.tgz
 - cni/nsenter-2.27.1

--- a/packages/kubernetes/packaging
+++ b/packages/kubernetes/packaging
@@ -1,7 +1,7 @@
 set -e
 
 KUBERNETES_PACKAGE=common-core-kubernetes
-KUBERNETES_VERSION="1.18.8+vmware.1"
+KUBERNETES_VERSION="1.18.12+vmware.2"
 
 main() {
   create_target_dir

--- a/packages/kubernetes/spec
+++ b/packages/kubernetes/spec
@@ -3,4 +3,4 @@ name: kubernetes
 
 files:
 - container-images/*
-- common-core-kubernetes-1.18.8+vmware.1/*
+- common-core-kubernetes-1.18.12+vmware.2/*


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**
https://pks.ci.cf-app.com/teams/bosh-lifecycle-dev/pipelines/pks-api-1.9.x-bump-kubernetes-1.18.12?group=all

**Is there any change in kubo-deployment?**

**Is there any change in kubo-ci?**
NO
**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
