### PR TITLE
Bumps kubernetes 1.19.6+vmware.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,38 +10,38 @@ cifs-utils-6.7.tar.bz2:
   size: 363647
   object_id: c529967d-57fa-4b41-685e-ff0a507ffaad
   sha: 9ba5091d7c2418a90773c861f04a3f4a36854c14
-cni/cni-plugins-amd64-v0.8.7+vmware.3.tgz:
-  size: 39810209
-  object_id: aa18f17d-8729-43a8-5be8-89f1b1fe5b9a
-  sha: sha256:f50c9c152223f03ddbfa0d8deafebce9ea2720ecd838c28aee4e4680ce3be5e3
+cni/cni-plugins-amd64-v0.8.7+vmware.4.tgz:
+  size: 39816898
+  object_id: cb7aec50-f5d1-4bc5-4cfc-1b02e6e59063
+  sha: sha256:03f2644df790c239b765dd7b17db9656065b7c5d8abbddaf5f9ccef97b87e545
 cni/nsenter-2.27.1:
   size: 27520
   object_id: f78a843e-4bf1-47c4-578b-786fcf8a2c94
   sha: sha256:9999ffda41275f924bcbb1d9d7b129421838d917236511eccacae7dc0ad631a9
-common-core-kubernetes-1.19.4+vmware.2/kube-apiserver:
-  size: 159647947
-  object_id: c89a4daf-4535-43c9-7bc4-047f29ff067d
-  sha: sha256:1e757258ac3a314a7e016ad9767d4e4c25456d035636ab4c00d63d52961714f4
-common-core-kubernetes-1.19.4+vmware.2/kube-controller-manager:
-  size: 150002895
-  object_id: 62409d4e-2932-4efc-6e36-f5d5316f40df
-  sha: sha256:6f8f853fbb16cca13e606976918ef7a1f012cf5c078474817040347714e8eb20
-common-core-kubernetes-1.19.4+vmware.2/kube-proxy:
-  size: 55039006
-  object_id: 83a3e83a-71fa-4109-4ab9-31d7d6a24ee9
-  sha: sha256:cb27d12caf5982b375fe4e6684520bf91c9999dd0ee0e29a798abb28d9eec183
-common-core-kubernetes-1.19.4+vmware.2/kube-scheduler:
-  size: 60286325
-  object_id: ec79a468-8b1a-4496-6eff-58dfd1226514
-  sha: sha256:517901883e2f84add2de4595f0b8004c68aba8a3dfba805e027c4edf5e7a5141
-common-core-kubernetes-1.19.4+vmware.2/kubectl:
-  size: 60377130
-  object_id: de74ac08-9806-4b00-636a-9a3c342d52b2
-  sha: sha256:15c137143d4a36c3ac25640f6672cb226c471a822cc4f2cf5a094c645ed68624
-common-core-kubernetes-1.19.4+vmware.2/kubelet:
-  size: 151223088
-  object_id: 77eb03c2-c639-461b-44e8-f4ac3be54f73
-  sha: sha256:10745bea3f8892733fd5c42e8093e7107948c50939fe6192eb9ae97b34792371
+common-core-kubernetes-1.19.6+vmware.1/kube-apiserver:
+  size: 159419413
+  object_id: 30146007-8b3c-4b65-48eb-0a80ea07db6f
+  sha: sha256:294710895c53c83410302f953fad3d8641f9b529a4c3f245ed13cd3772abfbb4
+common-core-kubernetes-1.19.6+vmware.1/kube-controller-manager:
+  size: 149791622
+  object_id: 05c011cf-b032-473c-7e97-23a5799238b0
+  sha: sha256:2e7c84931b7849603e8e35045f6046ca75e971f7bf4d500cffb2264d64597cce
+common-core-kubernetes-1.19.6+vmware.1/kube-proxy:
+  size: 54975596
+  object_id: 7d15313c-97fc-4335-6b19-c955ea9560cf
+  sha: sha256:ed8b9747d1b6c80a4b93ce12cd4a967fd3aed451a2958158ee0f98f0fbae6cc2
+common-core-kubernetes-1.19.6+vmware.1/kube-scheduler:
+  size: 60193769
+  object_id: 4e5d5fb2-8f61-464d-4ee1-9d5b63240bac
+  sha: sha256:c3ce2c5e5414038864d51700bf7bd6f4ed178f847459c21e5cfd9a3dbf097940
+common-core-kubernetes-1.19.6+vmware.1/kubectl:
+  size: 60288196
+  object_id: 47f5500f-369c-42bf-44eb-09f83facd68c
+  sha: sha256:e923a1757a3cc293f77af91f088a484142ecf2cd723f032a74fc9d54b2620518
+common-core-kubernetes-1.19.6+vmware.1/kubelet:
+  size: 151022296
+  object_id: a3e08887-e0bb-4d4d-5737-14c23ab24df2
+  sha: sha256:84b03545c6a439c9189655df656eadc98fcc01513954a0e144d6b989ef107935
 conntrack/conntrack_1.4.3-3_amd64.deb:
   size: 27346
   object_id: 0c4aa633-3de8-4a8c-7170-36b3fc9e4a9c
@@ -54,10 +54,10 @@ container-images/simple-server.tgz:
   size: 11953836
   object_id: d362a1a2-0a96-4e73-67a6-2e8565edc489
   sha: sha256:8c0c566079241cb5ec0c6708b47e2ee71b5dc470caa1cef62b0b2c671e784ef8
-container-images/vmware_coredns:1.7.0_vmware.5.tgz:
-  size: 12776123
-  object_id: 9f034b25-3ad2-46dd-6178-ddce67d40224
-  sha: sha256:bb48764845902bb7b2fc38a77315156c5dd7b512189790655c23a1f060c200b6
+container-images/vmware_coredns:1.7.0_vmware.6.tgz:
+  size: 12774845
+  object_id: 50497983-06f0-4390-6585-07a5045d37da
+  sha: sha256:b92494711d489b9c38e1b0b9cf38ce1238ca1852a337900192293b58bc85c8da
 container-images/vmware_metrics-server-amd64:v0.3.6.tgz:
   size: 12062146
   object_id: 301b9879-c1bf-42bb-6d90-f05929118056

--- a/jobs/apply-specs/templates/specs/coredns.yml.erb
+++ b/jobs/apply-specs/templates/specs/coredns.yml.erb
@@ -102,7 +102,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: registry.tkg.vmware.run/coredns:v1.7.0_vmware.5
+        image: registry.tkg.vmware.run/coredns:v1.7.0_vmware.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/packages/cni/packaging
+++ b/packages/cni/packaging
@@ -3,7 +3,7 @@ set -exu
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 
 CNI_PACKAGE="cni-plugins"
-CNI_VERSION="0.8.7+vmware.3"
+CNI_VERSION="0.8.7+vmware.4"
 
 NSENTER_VERSION="2.27.1"
 

--- a/packages/cni/spec
+++ b/packages/cni/spec
@@ -2,5 +2,5 @@
 name: cni
 
 files:
-- cni/cni-plugins-amd64-v0.8.7+vmware.3.tgz
+- cni/cni-plugins-amd64-v0.8.7+vmware.4.tgz
 - cni/nsenter-2.27.1

--- a/packages/kubernetes/packaging
+++ b/packages/kubernetes/packaging
@@ -1,7 +1,7 @@
 set -e
 
 KUBERNETES_PACKAGE=common-core-kubernetes
-KUBERNETES_VERSION="1.19.4+vmware.2"
+KUBERNETES_VERSION="1.19.6+vmware.1"
 
 main() {
   create_target_dir

--- a/packages/kubernetes/spec
+++ b/packages/kubernetes/spec
@@ -3,4 +3,4 @@ name: kubernetes
 
 files:
 - container-images/*
-- common-core-kubernetes-1.19.4+vmware.2/*
+- common-core-kubernetes-1.19.6+vmware.1/*


### PR DESCRIPTION
**What this PR does / why we need it**:
https://jira.eng.vmware.com/browse/PKS-3684

**How can this PR be verified?**
https://pks.ci.cf-app.com/teams/bosh-lifecycle-dev/pipelines/pks-api-1.10.x-bump-kubernetes-1.19.6?group=all

**Is there any change in kubo-deployment?**

**Is there any change in kubo-ci?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
