### PR TITLE
Set open files limit to 65535 for kube-proxy

### DIFF
--- a/jobs/kube-proxy/templates/bin/kube_proxy_ctl.erb
+++ b/jobs/kube-proxy/templates/bin/kube_proxy_ctl.erb
@@ -45,6 +45,8 @@ start_kubernetes_proxy() {
 
   sed -i "s|HOSTNAMEOVERRIDE|$(get_hostname_override)|g"  /var/vcap/jobs/kube-proxy/config/config.yml
 
+ ulimit -n 65535
+
  kube-proxy \
   <%-
     if_p('k8s-args') do |args|


### PR DESCRIPTION
**What this PR does / why we need it**:

current kube-proxy limits is default to system value 1024, we need to tune it to 65536 based on:

1.  Antrea scale test issue: https://bugzilla.eng.vmware.com/show_bug.cgi?id=2696987 (current PR did not fix this issue, but address open files limits problem, as for kube-proxy cannot open NodePort, need reproduce and more investigation)
2. upstream kubernetes experience: https://github.com/kubernetes/kubernetes/pull/12443

current kubelet:

```
# cat /proc/$(pidof kubelet)/limits | grep files
Max open files            1000000              1000000              files
```

current apiserver:
```
# cat /proc/$(pidof kube-apiserver)/limits | grep files
Max open files            65535                65535                files
```

**How can this PR be verified?**

Login into worker vm, execute:

Before this PR:
```
cat /proc/$(pidof kube-proxy)/limits | grep files
Max open files            1024                4096                files
```

After this PR:
```
# cat /proc/$(pidof kube-proxy)/limits | grep files
Max open files            65535                65535                files
```

pks-api pipeline:

https://pks.ci.cf-app.com/teams/pks-networking/pipelines/pks-api-1.10.x-dp 

**Is there any change in kubo-deployment?**

**Is there any change in kubo-ci?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
