### PR TITLE
Bump kubernetes 1.19.9+vmware.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,7 @@
+Python-2.7.18.tgz:
+  size: 17539408
+  object_id: b5c53ae4-9dd5-47a8-56a1-314e6f64d670
+  sha: sha256:da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814
 autoconf-2.69.tar.gz:
   size: 1927468
   object_id: 2e4a01bd-aa1e-4fbc-5f56-80aa40d805e3

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,38 +10,38 @@ cifs-utils-6.7.tar.bz2:
   size: 363647
   object_id: c529967d-57fa-4b41-685e-ff0a507ffaad
   sha: 9ba5091d7c2418a90773c861f04a3f4a36854c14
-cni/cni-plugins-amd64-v0.8.7+vmware.4.tgz:
-  size: 39816898
-  object_id: cb7aec50-f5d1-4bc5-4cfc-1b02e6e59063
-  sha: sha256:03f2644df790c239b765dd7b17db9656065b7c5d8abbddaf5f9ccef97b87e545
+cni/cni-plugins-amd64-v0.8.7+vmware.6.tgz:
+  size: 39904590
+  object_id: 51096719-870a-4a88-6ed1-c8d4e9538d02
+  sha: 75adfe5ac5d1f9f01870eefdd3f650365787493b
 cni/nsenter-2.27.1:
   size: 27520
   object_id: f78a843e-4bf1-47c4-578b-786fcf8a2c94
   sha: sha256:9999ffda41275f924bcbb1d9d7b129421838d917236511eccacae7dc0ad631a9
-common-core-kubernetes-1.19.6+vmware.1/kube-apiserver:
-  size: 159419413
-  object_id: 30146007-8b3c-4b65-48eb-0a80ea07db6f
-  sha: sha256:294710895c53c83410302f953fad3d8641f9b529a4c3f245ed13cd3772abfbb4
-common-core-kubernetes-1.19.6+vmware.1/kube-controller-manager:
-  size: 149791622
-  object_id: 05c011cf-b032-473c-7e97-23a5799238b0
-  sha: sha256:2e7c84931b7849603e8e35045f6046ca75e971f7bf4d500cffb2264d64597cce
-common-core-kubernetes-1.19.6+vmware.1/kube-proxy:
-  size: 54975596
-  object_id: 7d15313c-97fc-4335-6b19-c955ea9560cf
-  sha: sha256:ed8b9747d1b6c80a4b93ce12cd4a967fd3aed451a2958158ee0f98f0fbae6cc2
-common-core-kubernetes-1.19.6+vmware.1/kube-scheduler:
-  size: 60193769
-  object_id: 4e5d5fb2-8f61-464d-4ee1-9d5b63240bac
-  sha: sha256:c3ce2c5e5414038864d51700bf7bd6f4ed178f847459c21e5cfd9a3dbf097940
-common-core-kubernetes-1.19.6+vmware.1/kubectl:
-  size: 60288196
-  object_id: 47f5500f-369c-42bf-44eb-09f83facd68c
-  sha: sha256:e923a1757a3cc293f77af91f088a484142ecf2cd723f032a74fc9d54b2620518
-common-core-kubernetes-1.19.6+vmware.1/kubelet:
-  size: 151022296
-  object_id: a3e08887-e0bb-4d4d-5737-14c23ab24df2
-  sha: sha256:84b03545c6a439c9189655df656eadc98fcc01513954a0e144d6b989ef107935
+common-core-kubernetes-1.19.9+vmware.1/kube-apiserver:
+  size: 115245056
+  object_id: 41377a4e-4fa1-4b23-768a-a518038bd6a6
+  sha: a102ac42d0aea376ab76cd81a287124a67205b0e
+common-core-kubernetes-1.19.9+vmware.1/kube-controller-manager:
+  size: 107237376
+  object_id: 13990ac6-10e1-419a-6819-e3857fccbd77
+  sha: 5b4b92a31b79354490c7b3d117b2859c22902a97
+common-core-kubernetes-1.19.9+vmware.1/kube-proxy:
+  size: 38780928
+  object_id: 25d954f9-e080-428f-4377-50a84d5bed48
+  sha: 496e804b08f49a4f997905f9c3aafd7cefd4bb90
+common-core-kubernetes-1.19.9+vmware.1/kube-scheduler:
+  size: 42946560
+  object_id: 59ad15bb-0901-45a4-765a-c44012d3d25d
+  sha: 9844c26bdf934e102664784fcae9039cfc7f675e
+common-core-kubernetes-1.19.9+vmware.1/kubectl:
+  size: 42975232
+  object_id: ca163eef-5de7-4c05-5f9e-7edfb70e106d
+  sha: df64546e8c68440e7813bfff3fc3810ef3b8332a
+common-core-kubernetes-1.19.9+vmware.1/kubelet:
+  size: 110011496
+  object_id: f4f085bc-a3b2-4808-40bd-474c70a450f6
+  sha: c823a304f2bf50caa5ee98be1f8db8561883c6e5
 conntrack/conntrack_1.4.3-3_amd64.deb:
   size: 27346
   object_id: 0c4aa633-3de8-4a8c-7170-36b3fc9e4a9c
@@ -54,10 +54,10 @@ container-images/simple-server.tgz:
   size: 11953836
   object_id: d362a1a2-0a96-4e73-67a6-2e8565edc489
   sha: sha256:8c0c566079241cb5ec0c6708b47e2ee71b5dc470caa1cef62b0b2c671e784ef8
-container-images/vmware_coredns:1.7.0_vmware.6.tgz:
-  size: 12774845
-  object_id: 50497983-06f0-4390-6585-07a5045d37da
-  sha: sha256:b92494711d489b9c38e1b0b9cf38ce1238ca1852a337900192293b58bc85c8da
+container-images/vmware_coredns:1.7.0_vmware.8.tgz:
+  size: 12792899
+  object_id: 51d8f9ea-5b20-4247-451c-b55665569ef3
+  sha: 862529513e1a0a7f85aa2330c76adc5a2bee2113
 container-images/vmware_metrics-server-amd64:v0.3.6.tgz:
   size: 12062146
   object_id: 301b9879-c1bf-42bb-6d90-f05929118056

--- a/jobs/apply-specs/templates/specs/coredns.yml.erb
+++ b/jobs/apply-specs/templates/specs/coredns.yml.erb
@@ -102,7 +102,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: registry.tkg.vmware.run/coredns:v1.7.0_vmware.6
+        image: projects.registry.vmware.com/tkg/coredns:v1.7.0_vmware.8
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/packages/cifs-utils/spec
+++ b/packages/cifs-utils/spec
@@ -1,6 +1,9 @@
 ---
 name: cifs-utils
 
+dependencies: 
+- python2
+
 files:
   - autoconf-2.69.tar.gz
   - automake-1.15.tar.gz

--- a/packages/cni/packaging
+++ b/packages/cni/packaging
@@ -3,7 +3,7 @@ set -exu
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 
 CNI_PACKAGE="cni-plugins"
-CNI_VERSION="0.8.7+vmware.4"
+CNI_VERSION="0.8.7+vmware.6"
 
 NSENTER_VERSION="2.27.1"
 

--- a/packages/cni/spec
+++ b/packages/cni/spec
@@ -2,5 +2,5 @@
 name: cni
 
 files:
-- cni/cni-plugins-amd64-v0.8.7+vmware.4.tgz
+- cni/cni-plugins-amd64-v0.8.7+vmware.6.tgz
 - cni/nsenter-2.27.1

--- a/packages/kubernetes/packaging
+++ b/packages/kubernetes/packaging
@@ -1,7 +1,7 @@
 set -e
 
 KUBERNETES_PACKAGE=common-core-kubernetes
-KUBERNETES_VERSION="1.19.6+vmware.1"
+KUBERNETES_VERSION="1.19.9+vmware.1"
 
 main() {
   create_target_dir

--- a/packages/kubernetes/spec
+++ b/packages/kubernetes/spec
@@ -3,4 +3,4 @@ name: kubernetes
 
 files:
 - container-images/*
-- common-core-kubernetes-1.19.6+vmware.1/*
+- common-core-kubernetes-1.19.9+vmware.1/*

--- a/packages/python2/packaging
+++ b/packages/python2/packaging
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e -x
+
+PYTHON2_PACKAGE="python2"
+PYTHON2_VERSION="2.7.18"
+
+CPUS=`grep -c ^processor /proc/cpuinfo`
+
+tar xzf Python-2.7.*.tgz
+pushd Python-2.7.*
+	./configure --prefix=${BOSH_INSTALL_TARGET}
+
+	make -j${CPUS}
+	make install
+	ln -s ${BOSH_INSTALL_TARGET}/bin/python2  /usr/bin/python2
+	ln -s ${BOSH_INSTALL_TARGET}/bin/python2  /usr/bin/python
+popd
+
+
+# Open Source Licensing Information, used by the vmware OSM system
+# These license abbreviations are defined by the OSM system
+# See https://github.com/pivotal-cf/pks-bosh-lifecycle-home/tree/master/osl/osm-blob-manifests
+
+PYTHON2_SOURCE_URL="https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz"
+PYTHON2_LICENSE="PSF"
+
+cat <<EOF > ${BOSH_INSTALL_TARGET}/osl-package.json
+{ "packages": [
+    {
+    "name": "$PYTHON2_PACKAGE",
+    "version": "$PYTHON2_VERSION",
+    "url": "$PYTHON2_SOURCE_URL",
+    "license": "$PYTHON2_LICENSE"
+    }
+]}
+EOF

--- a/packages/python2/spec
+++ b/packages/python2/spec
@@ -1,0 +1,7 @@
+---
+name: python2
+
+dependencies: []
+
+files:
+  - Python-2.7.18.tgz  #From  https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**

**Is there any change in kubo-deployment?**

**Is there any change in kubo-ci?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

- bump kubernetes 1.19.1
- add python2 packages

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
