### PR TITLE
Add python packages

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,7 @@
+Python-2.7.18.tgz:
+  size: 17539408
+  object_id: b5c53ae4-9dd5-47a8-56a1-314e6f64d670
+  sha: sha256:da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814
 autoconf-2.69.tar.gz:
   size: 1927468
   object_id: 2e4a01bd-aa1e-4fbc-5f56-80aa40d805e3

--- a/packages/cifs-utils/spec
+++ b/packages/cifs-utils/spec
@@ -1,6 +1,9 @@
 ---
 name: cifs-utils
 
+dependencies: 
+- python2
+
 files:
   - autoconf-2.69.tar.gz
   - automake-1.15.tar.gz

--- a/packages/python2/packaging
+++ b/packages/python2/packaging
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e -x
+
+PYTHON2_PACKAGE="python2"
+PYTHON2_VERSION="2.7.18"
+
+CPUS=`grep -c ^processor /proc/cpuinfo`
+
+tar xzf Python-2.7.*.tgz
+pushd Python-2.7.*
+	./configure --prefix=${BOSH_INSTALL_TARGET}
+
+	make -j${CPUS}
+	make install
+	ln -s ${BOSH_INSTALL_TARGET}/bin/python2  /usr/bin/python2
+	ln -s ${BOSH_INSTALL_TARGET}/bin/python2  /usr/bin/python
+popd
+
+
+# Open Source Licensing Information, used by the vmware OSM system
+# These license abbreviations are defined by the OSM system
+# See https://github.com/pivotal-cf/pks-bosh-lifecycle-home/tree/master/osl/osm-blob-manifests
+
+PYTHON2_SOURCE_URL="https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz"
+PYTHON2_LICENSE="PSF"
+
+cat <<EOF > ${BOSH_INSTALL_TARGET}/osl-package.json
+{ "packages": [
+    {
+    "name": "$PYTHON2_PACKAGE",
+    "version": "$PYTHON2_VERSION",
+    "url": "$PYTHON2_SOURCE_URL",
+    "license": "$PYTHON2_LICENSE"
+    }
+]}
+EOF

--- a/packages/python2/spec
+++ b/packages/python2/spec
@@ -1,0 +1,7 @@
+---
+name: python2
+
+dependencies: []
+
+files:
+  - Python-2.7.18.tgz  #From  https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tgz


### PR DESCRIPTION
 python2.7.18 and create soft link to /usr/bin/python
 Since compiling cifs depends on python

**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**

**Is there any change in kubo-deployment?**

**Is there any change in kubo-ci?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
