### PR TITLE
Revert runc to rc10 due to a regression in upstream runc library

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -82,10 +82,10 @@ docker/bridge-utils-1.5.tar.gz:
   size: 33472
   object_id: 8235dfbc-d475-4b0f-7682-cc912fc8fdcd
   sha: sha256:80c18ef50bff135f406bfc503ca832f9e3a33f314cce85717a4dbd2b36409bd2
-docker/docker-19.03.14-containerd-1.4.4-runc93.tgz:
-  size: 68830116
-  object_id: 9bdc9a64-b03e-4e9a-7ed5-a9fff2807625
-  sha: sha256:a396b27fb4f17b6228d683984a1da4b6c7e181519bd241227d9ed0fdf4686d4b
+docker/docker-19.03.14.tgz:
+  size: 62435231
+  object_id: 440b7210-69ea-4a69-417e-fc6503c8401f
+  sha: sha256:9f1ec28e357a8f18e9561129239caf9c0807d74756e21cc63637c7fdeaafe847
 etcd/etcd-v3.4.13-linux-amd64.tar.gz:
   size: 17373136
   object_id: dbe2cf3f-a669-4075-5c27-d88cbc577a2e

--- a/packages/docker/packaging
+++ b/packages/docker/packaging
@@ -38,7 +38,7 @@ make install
 
 # Extract docker package
 DOCKER_PACKAGE=docker
-DOCKER_VERSION="19.03.14-containerd-1.4.4-runc93"
+DOCKER_VERSION="19.03.14"
 echo "Extracting docker ${DOCKER_VERSION}..."
 tar xzvf ${BOSH_COMPILE_TARGET}/docker/${DOCKER_PACKAGE}-${DOCKER_VERSION}.tgz
 if [[ $? != 0 ]] ; then

--- a/packages/docker/spec
+++ b/packages/docker/spec
@@ -4,4 +4,4 @@ dependencies: []
 files:
   - docker/autoconf-2.69.tar.gz
   - docker/bridge-utils-1.5.tar.gz
-  - docker/docker-19.03.14-containerd-1.4.4-runc93.tgz
+  - docker/docker-19.03.14.tgz


### PR DESCRIPTION
It can potentially run into an issue where the worker nodes can end up in an unhealthy state
This issue results in kubelet failing with error message "PLEG is not healthy"

**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**
https://pks.ci.cf-app.com/teams/bosh-lifecycle-dev/pipelines/pks-api-1.11.x-revert-runc-to-rc10?group=all

**Is there any change in kubo-deployment?**

**Is there any change in kubo-ci?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
