### PR TITLE
Bump docker 20.10.7 on 1.9.x

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -82,10 +82,10 @@ docker/bridge-utils-1.5.tar.gz:
   size: 33472
   object_id: 8235dfbc-d475-4b0f-7682-cc912fc8fdcd
   sha: sha256:80c18ef50bff135f406bfc503ca832f9e3a33f314cce85717a4dbd2b36409bd2
-docker/docker-19.03.14-containerd-1.4.6-runc95.tgz:
-  size: 70825655
-  object_id: bc06b5e4-2822-49c9-515d-1f7488a6cd27
-  sha: sha256:aaf2bbf5336cef22147fff40973f7b725a1d0740fa2ccea610726b8bd7d06c50
+docker/docker-20.10.7.tgz:
+  size: 69725147
+  object_id: 65ce8f90-8b9c-4a8e-789f-186bf699935b
+  sha: sha256:34ad50146fce29b28e5115a1e8510dd5232459c9a4a9f28f65909f92cca314d9
 etcd/etcd-v3.4.3-linux-amd64.tar.gz:
   size: 17280028
   object_id: 6919516e-a048-46df-56a8-170cf71d58ff

--- a/packages/docker/packaging
+++ b/packages/docker/packaging
@@ -38,7 +38,7 @@ make install
 
 # Extract docker package
 DOCKER_PACKAGE=docker
-DOCKER_VERSION="19.03.14-containerd-1.4.6-runc95"
+DOCKER_VERSION="20.10.7"
 echo "Extracting docker ${DOCKER_VERSION}..."
 tar xzvf ${BOSH_COMPILE_TARGET}/docker/${DOCKER_PACKAGE}-${DOCKER_VERSION}.tgz
 if [[ $? != 0 ]] ; then
@@ -61,9 +61,9 @@ AUTOCONF_SOURCE_URL="http://ftp.gnu.org/gnu/autoconf/$AUTOCONF_PACKAGE-$AUTOCONF
 BRIDGE_UTILS_SOURCE_URL="https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/bridge-utils/1.5-15ubuntu1/bridge-utils_1.5.orig.tar.gz"
 BRIDGE_UTILS_LICENSE="GPL2.0"
 
-# source: https://github.com/docker/docker-ce/blob/v19.03.14/components/engine/LICENSE
+# source: https://github.com/moby/moby/blob/v20.10.7/LICENSE
 DOCKER_LICENSE="Apache2.0"
-DOCKER_SOURCE_URL="https://github.com/docker/docker-ce/archive/v19.03.14.zip"
+DOCKER_SOURCE_URL="https://github.com/moby/moby/archive/refs/tags/v20.10.7.zip"
 
 cat <<EOF > ${BOSH_INSTALL_TARGET}/osl-package.json
 { "packages": [

--- a/packages/docker/spec
+++ b/packages/docker/spec
@@ -4,4 +4,4 @@ dependencies: []
 files:
   - docker/autoconf-2.69.tar.gz
   - docker/bridge-utils-1.5.tar.gz
-  - docker/docker-19.03.14-containerd-1.4.6-runc95.tgz
+  - docker/docker-20.10.7.tgz


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**
https://pks.ci.cf-app.com/teams/bosh-lifecycle-dev/pipelines/pks-api-1.9.x-bump-docker-20.10.7
**Is there any change in kubo-deployment?**

**Is there any change in kubo-ci?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
